### PR TITLE
Fix z-index on component layer for small components

### DIFF
--- a/zeplinpar.js
+++ b/zeplinpar.js
@@ -53,3 +53,12 @@ observer.observe(targetNode, config);
 }
 
 zeplinObserve();
+
+function zeplinZIndexFix() {
+	
+	//	Put component label behind measure label
+	const componentLabel = document.querySelector('.componentLayer a');
+	componentLabel.setAttribute('style', 'z-index: auto');
+}
+
+zeplinZIndexFix();


### PR DESCRIPTION
Zeplin components labels are above measure layer on small components, so measures are unreadabele. This fix puts components layers behind because on right panel there are already component references.